### PR TITLE
Remove retry rule in `FtpClient.cs`

### DIFF
--- a/Src/CrispyWaffle.Utils/Communications/FtpClient.cs
+++ b/Src/CrispyWaffle.Utils/Communications/FtpClient.cs
@@ -147,11 +147,10 @@ namespace CrispyWaffle.Utils.Communications
                 request.ReadWriteTimeout = 90000;
                 request.UsePassive = true;
 
-                var response = (FtpWebResponse)request.GetResponse();
-                var responseStream = response.GetResponseStream();
-
-                using (var reader = new StreamReader(responseStream))
+                using var response = (FtpWebResponse)request.GetResponse();
+                using (var responseStream = response.GetResponseStream())
                 {
+                    using var reader = new StreamReader(responseStream);
                     while (!reader.EndOfStream)
                     {
                         _files.Enqueue(reader.ReadLine());


### PR DESCRIPTION
This closes #211 

I've removed the retry rule in the `CreateInternal` method in `FtpClient.cs`:

- removed the `while(true)` statement
- removed the `attempts` variable and incrementation
- removed the `if` statement checking for the attempt count

In the spirit of improving the code, I also slightly changed the `ExistsInternal` method to simplify the resource management and simplify the code slightly.

but let me know if you want me to revert the changes made to `ExistsInternal`

P.S. Could you kindly please add the label `hacktoberfest-accepted` to this pull request?

Thank you.