### PR TITLE
Install .NET 8 in AppVeyor

### DIFF
--- a/Tests/CrispyWaffle.Tests/CrispyWaffle.Tests.csproj
+++ b/Tests/CrispyWaffle.Tests/CrispyWaffle.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ProjectGuid>FAE04EC0-301F-11D3-BF4B-00C04F79EFBC</ProjectGuid>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,8 @@ init:
 - SET PATH=%JAVA_HOME%\bin;%PATH%
 
 before_build:
+- ps: (New-Object System.Net.WebClient).DownloadFile('https://dot.net/v1/dotnet-install.ps1', "$env:appveyor_build_folder\dotnet-install.ps1")
+- ps: ./dotnet-install.ps1 -Channel LTS
 - ps: $env:SOLUTION_NAME = $([io.path]::GetFileNameWithoutExtension($(Get-ChildItem -Path .\* -Include *.sln)))
 - ps: $env:SONAR_PROJECT = "$env:APPVEYOR_REPO_NAME" -replace "/","_"
 - ps: $env:SONAR_ORGANIZATION = "$env:APPVEYOR_REPO_NAME" -replace "/.*$","-github"


### PR DESCRIPTION
This update installs the latest version of the .NET, version 8, released on Nov 2023 in AppVeyor since it currently does not ship with the .NET 8.