### PR TITLE
Drop support to .NET 6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="SDK Versions">
-    <DotNetVersions>netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0</DotNetVersions>
+    <DotNetVersions>netstandard2.0;netstandard2.1;net8.0;net9.0</DotNetVersions>
     <DotNetVersionTests>net9.0</DotNetVersionTests>
   </PropertyGroup>
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 9.1.{build}
+version: 10.0.{build}
 skip_tags: true
 image: Visual Studio 2022
 configuration: Release

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Version 10.0 [2025-02-22]
+
+- Drop support to .NET 6 - [pull request #667](https://github.com/guibranco/CrispyWaffle/pull/667)
+
+## Version 9.1 []
+
+- TBC
+
+## Version 9.0 []
+
+- TBC
+
 ## Version 8.2 [2024-09-11]
 
 - Implement CouchDB cache - [issue #499](https://github.com/guibranco/CrispyWaffle/issues/499) and [pull request #544](https://github.com/guibranco/CrispyWaffle/pull/544) by [@Mohammad-Haris](https://github.com/Mohammad-Haris)


### PR DESCRIPTION
## 📑 Description
Drop support to .NET 6

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [X] Yes
- [ ] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Summary by Sourcery

This pull request drops support for .NET 6, updating the project to a newer .NET version.

Enhancements:
- The project now targets a newer .NET version, taking advantage of the latest features and improvements.

Build:
- The build configuration has been updated to remove support for .NET 6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Revised compatibility settings to support updated runtime versions while discontinuing an older version.
	- Adjusted build configuration to adopt a new major version number.
- **Documentation**
	- Updated the release notes with a new version entry and additional upcoming release details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->