### PR TITLE
[FEATURE] Add SHA3 algorithms for .NET 8+

### DIFF
--- a/Src/CrispyWaffle/Cryptography/HashAlgorithmType.cs
+++ b/Src/CrispyWaffle/Cryptography/HashAlgorithmType.cs
@@ -29,4 +29,21 @@ public enum HashAlgorithmType
     /// The SHA-512 algorithm.
     /// </summary>
     Sha512,
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// The SHA3-256 algorithm. Available in .NET 8.0 and later.
+    /// </summary>
+    Sha3_256,
+
+    /// <summary>
+    /// The SHA3-384 algorithm. Available in .NET 8.0 and later.
+    /// </summary>
+    Sha3_384,
+
+    /// <summary>
+    /// The SHA3-512 algorithm. Available in .NET 8.0 and later.
+    /// </summary>
+    Sha3_512,
+#endif
 }

--- a/Src/CrispyWaffle/Cryptography/Security.cs
+++ b/Src/CrispyWaffle/Cryptography/Security.cs
@@ -157,5 +157,10 @@ public static class Security
         { HashAlgorithmType.Sha256, SHA256.Create() },
         { HashAlgorithmType.Sha384, SHA384.Create() },
         { HashAlgorithmType.Sha512, SHA512.Create() },
+#if NET8_0_OR_GREATER
+        { HashAlgorithmType.Sha3_256, SHA3_256.Create() },
+        { HashAlgorithmType.Sha3_384, SHA3_384.Create() },
+        { HashAlgorithmType.Sha3_512, SHA3_512.Create() },
+#endif
     };
 }


### PR DESCRIPTION
## 📑 Description
Introduce `SHA3_256`, `SHA3_384` and `SHA3_512` enum members to `HashAlgorithmType`, guarded by the `NET8_0_OR_GREATER` preprocessor symbol, and register their corresponding SHA3 implementations in `CrispyWaffle.Cryptography.Security`'s algorithm map, also guarded by the `NET8_0_OR_GREATER` preprocessor symbol.

This PR selectively enables the use of .NET 8+ built-in SHA3 hash algorithms when targeting .NET 8 or later, while still compiling correctly for older supported frameworks.

<!-- 
You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and check the following fields as needed -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
<!-- If this introduces a breaking change, make sure to note it here and what the impact might be -->
- [ ] Yes
- [X] No

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

All added code is wrapped within a C# preprocessor `#if NET8_0_OR_GREATER` block, so this PR is backward-compatible with existing code, regardless of the target framework. Existing code targeting .NET 7 or below requires no changes; the new hash algorithms simply won't be available on those frameworks, nor appear in IntelliSense.

## Summary by Sourcery

Add support for SHA3 hash algorithms when targeting .NET 8 or later.

New Features:
- Introduce SHA3_256, SHA3_384, and SHA3_512 options in the HashAlgorithmType enum for .NET 8+ targets.
- Register .NET 8+ built-in SHA3 implementations in the cryptography algorithm map to enable hashing with these algorithms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for SHA-3 cryptographic hash algorithms (256-bit, 384-bit, and 512-bit variants) for .NET 8 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->