### PR TITLE
chore: update to .NET 10 and adjust related configurations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,4 +123,4 @@ jobs:
           ./bin/deepsource report \
             --analyzer test-coverage \
             --key csharp \
-            --value-file ./Tests/CrispyWaffle.Tests/coverage.net9.0.cobertura.xml
+            --value-file ./Tests/CrispyWaffle.Tests/coverage.net10.0.cobertura.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         image: couchdb:3.3.3
         env:
           COUCHDB_USER: Admin
-          COUCHDB_PASSWORD: myP@ssw0rd
+          COUCHDB_PASSWORD: ${{ secrets.COUCHDB_PASSWORD }}
         ports:
           - 5984:5984
         options: >-
@@ -60,7 +60,9 @@ jobs:
         run: dotnet tool install --global dotnet-sonarscanner
 
       - name: 📡 Install DeepSource scanner
-        run: curl https://deepsource.io/cli | sh
+        run: |
+          curl --proto '=https' --tlsv1.2 -fsSLo deepsource-install.sh https://deepsource.io/cli
+          sh deepsource-install.sh
 
       - name: 💾 Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # 1️⃣ Checkout the repository
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # 2️⃣ Run Codacy Analysis CLI, produce results.sarif
       - name: Run Codacy Analysis CLI

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Set up .NET
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
@@ -32,14 +32,14 @@ jobs:
         dotnet-version: '10.x'
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         category: "security"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: '9.x'
+        dotnet-version: '10.x'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4

--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Run InferSharp
       uses: microsoft/infersharpaction@b749060de518f410f92c87d37d2366e5e9d7c5fc # v1.5
 
     - name: Upload SARIF results
       if: success() && steps.infersharp.outputs.sarif-report
-      uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         sarif_file: ${{ steps.infersharp.outputs.sarif-report }}
       continue-on-error: true

--- a/.github/workflows/infisical-secrets-check.yml
+++ b/.github/workflows/infisical-secrets-check.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     # Update this list if you add or remove sub-projects.
     env:
       PACKAGE_PROJECTS: "Configuration ElasticSearch Elmah EventLog I18n.PtBr Log4Net RabbitMQ Redis Utils"
-      TARGET_FRAMEWORKS: "netstandard2.0 netstandard2.1 net8.0 net9.0"
+      TARGET_FRAMEWORKS: "netstandard2.0 netstandard2.1 net8.0 net9.0 net10.0"
 
     # ── CouchDB & Redis service containers ────────────────────────────────────
     services:
@@ -129,7 +129,7 @@ jobs:
             "/d:sonar.branch.name=main" \
             "/d:sonar.exclusions=**/bin/**/*,**/obj/**/*" \
             "/d:sonar.coverage.exclusions=**/${SLN}.Tests/**,**/*Tests.cs" \
-            "/d:sonar.cs.opencover.reportsPaths=Tests/${SLN}.Tests/coverage.net9.0.opencover.xml"
+            "/d:sonar.cs.opencover.reportsPaths=Tests/${SLN}.Tests/coverage.net10.0.opencover.xml"
 
       # ── Build ─────────────────────────────────────────────────────────────────
       - name: Build
@@ -160,7 +160,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: Tests/${{ steps.solution.outputs.name }}.Tests/coverage.net9.0.opencover.xml
+          files: Tests/${{ steps.solution.outputs.name }}.Tests/coverage.net10.0.opencover.xml
           fail_ci_if_error: false
 
       - name: Report coverage → Codacy
@@ -172,7 +172,7 @@ jobs:
           java -jar codacy-reporter.jar report \
             -l CSharp \
             -t "${{ secrets.CODACY_PROJECT_TOKEN }}" \
-            -r "Tests/${SLN}.Tests/coverage.net9.0.opencover.xml"
+            -r "Tests/${SLN}.Tests/coverage.net10.0.opencover.xml"
 
       # ── SonarCloud: end ───────────────────────────────────────────────────────
       - name: SonarCloud – end scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       # ── Checkout ─────────────────────────────────────────────────────────────
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -254,7 +254,7 @@ jobs:
 
       # ── Push packages to NuGet.org ────────────────────────────────────────────
       - name: NuGet login (OIDC → temp API key)
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
         id: nuget-login
         with:
           user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         image: couchdb:3.3.3
         env:
           COUCHDB_USER: Admin
-          COUCHDB_PASSWORD: myP@ssw0rd
+          COUCHDB_PASSWORD: ${{ secrets.COUCHDB_PASSWORD }}
         ports:
           - 5984:5984
         options: >-
@@ -164,14 +164,16 @@ jobs:
           fail_ci_if_error: false
 
       - name: Report coverage → Codacy
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: |
           SLN="${{ steps.solution.outputs.name }}"
-          curl -fsSL \
+          curl --proto '=https' --tlsv1.2 -fsSL \
             https://github.com/codacy/codacy-coverage-reporter/releases/latest/download/codacy-coverage-reporter-assembly.jar \
             -o codacy-reporter.jar
           java -jar codacy-reporter.jar report \
             -l CSharp \
-            -t "${{ secrets.CODACY_PROJECT_TOKEN }}" \
+            -t "$CODACY_PROJECT_TOKEN" \
             -r "Tests/${SLN}.Tests/coverage.net10.0.opencover.xml"
 
       # ── SonarCloud: end ───────────────────────────────────────────────────────

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,17 +11,25 @@
         "statusBar.background": "#f9e64f",
         "statusBar.foreground": "#15202b",
         "statusBarItem.hoverBackground": "#f7df1e",
-        "statusBarItem.remoteBackground": "#f9e64f",
+        "statusBarItem.remoteBackground": "#059a89",
         "statusBarItem.remoteForeground": "#15202b",
         "titleBar.activeBackground": "#f9e64f",
         "titleBar.activeForeground": "#15202b",
         "titleBar.inactiveBackground": "#f9e64f99",
-        "titleBar.inactiveForeground": "#15202b99"
+        "titleBar.inactiveForeground": "#15202b99",
+        "activityBarTop.activeBackground": "#fbed80",
+        "activityBarTop.background": "#fbed80",
+        "activityBarTop.foreground": "#15202b",
+        "activityBarTop.inactiveForeground": "#15202b99",
+        "commandCenter.foreground": "#15202b",
+        "statusBar.debuggingBackground": "#f9e64f",
+        "statusBar.debuggingForeground": "#15202b"
     },
     "peacock.color": "#f9e64f",
     "sonarlint.connectedMode.project": {
         "connectionId": "guibranco",
         "projectKey": "guibranco_CrispyWaffle"
     },
-    "snyk.advanced.autoSelectOrganization": true
+    "snyk.advanced.autoSelectOrganization": true,
+    "sarif-viewer.connectToGithubCodeScanning": "on"
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Label="SDK Versions">
-    <DotNetVersions>netstandard2.0;netstandard2.1;net8.0;net9.0</DotNetVersions>
-    <DotNetVersionTests>net9.0</DotNetVersionTests>
+    <DotNetVersions>netstandard2.0;netstandard2.1;net8.0;net9.0;net10.0</DotNetVersions>
+    <DotNetVersionTests>net10.0</DotNetVersionTests>
   </PropertyGroup>
   <PropertyGroup Label="NuGet package">
     <Authors>Guilherme Branco Stracini</Authors>

--- a/Src/CrispyWaffle.BackgroundJobs/CrispyWaffle.BackgroundJobs.csproj
+++ b/Src/CrispyWaffle.BackgroundJobs/CrispyWaffle.BackgroundJobs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Src/CrispyWaffle.HttpClient/CrispyWaffle.HttpClient.csproj
+++ b/Src/CrispyWaffle.HttpClient/CrispyWaffle.HttpClient.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## 📑 Description
Update project files and workflows to target .NET 10. This moves from .NET 9 to .NET 10 to leverage the latest language features and performance improvements. Adjust the target framework in project settings and update workflows to use the new .NET version for builds, tests, and scanning. Additionally, update coverage report paths and other related configurations to ensure compatibility with .NET 10.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Update the repository to target .NET 10 across projects and CI workflows.

Build:
- Extend release workflow target frameworks to include net10.0.
- Update coverage report filenames and paths from net9.0 to net10.0 for SonarCloud, Codecov, Codacy, and DeepSource integrations.
- Switch CodeQL workflow to use the .NET 10 SDK instead of .NET 9.

CI:
- Align CI workflows with the new .NET 10 target and coverage artifacts for builds, tests, and code analysis.

Chores:
- Adjust shared project configuration and editor settings to use .NET 10 as the primary target framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added .NET 10.0 support for the Background Jobs and HTTP Client components.
  * Expanded CI build/test coverage to include .NET 10.0 across the framework targets.

* **Bug Fixes**
  * Updated coverage reporting and quality checks to use the .NET 10.0 coverage artifacts.
  * Improved reliability/security in CI by sourcing the CouchDB password from repository secrets.

* **Chores**
  * Refreshed pinned CI action revisions and updated CodeQL/coverage tooling for .NET 10.0.
  * Updated VS Code theme colors and enabled SARIF viewer connection to GitHub Code Scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upgrades the project from .NET 9 to .NET 10, updating target frameworks, CI workflow configurations, and coverage report paths across the board. `Directory.Build.props` adds `net10.0` to the multi-target list and sets the test TFM to `net10.0`, while two standalone sub-projects (`BackgroundJobs`, `HttpClient`) are bumped from `net8.0` directly to `net10.0`.

- **`Directory.Build.props`**: `DotNetVersions` now includes `net10.0` and `DotNetVersionTests` is set to `net10.0`, keeping multi-targeting intact for the main library.
- **Workflow files** (`build.yml`, `release.yml`, `codeql.yml`): .NET toolchain version updated to `10.x`/`10.0.x`; all hardcoded coverage report filenames updated from `net9.0` to `net10.0`; `release.yml` adds `net10.0` to `TARGET_FRAMEWORKS`.
- **`BackgroundJobs` / `HttpClient` csproj**: Both jump from `net8.0` to `net10.0` only — neither is a published NuGet package (`PACKAGE_PROJECTS` excludes them), and `BackgroundJobs` is not in the solution file, so CI does not build it.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all published packages continue to multi-target correctly, and CI is properly updated to use .NET 10 end-to-end.

The upgrade is consistent across workflows, Directory.Build.props, and the published packages. The only wrinkle is that CrispyWaffle.BackgroundJobs is not wired into the solution or the release pipeline, so its TargetFramework change from net8.0 to net10.0 is never compiled or tested by CI.

Src/CrispyWaffle.BackgroundJobs/CrispyWaffle.BackgroundJobs.csproj — changed but not included in CrispyWaffle.sln or PACKAGE_PROJECTS, so the change is unvalidated by CI.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Directory.Build.props | Adds net10.0 to multi-target list and sets test TFM to net10.0; straightforward and consistent. |
| .github/workflows/build.yml | dotnet-version already set to 10.0.x; DeepSource coverage path updated from net9.0 to net10.0 cobertura XML. Change is correct. |
| .github/workflows/release.yml | net10.0 added to TARGET_FRAMEWORKS; SonarCloud, Codecov, and Codacy coverage paths updated from net9.0 to net10.0. All changes are consistent. |
| .github/workflows/codeql.yml | dotnet-version updated from 9.x to 10.x; single-line change, correct. |
| Src/CrispyWaffle.HttpClient/CrispyWaffle.HttpClient.csproj | TargetFramework changed from net8.0 to net10.0, skipping net9.0. Not a published NuGet package, so no public compatibility concern, but drops net8.0/net9.0 support. |
| Src/CrispyWaffle.BackgroundJobs/CrispyWaffle.BackgroundJobs.csproj | TargetFramework changed from net8.0 to net10.0; project is absent from CrispyWaffle.sln, so this change is never exercised by CI builds or tests. |
| .vscode/settings.json | Added Peacock color customizations and sarif-viewer setting; developer-environment-only, no impact on builds. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR Merge to main] --> B[release.yml triggered]
    B --> C[Setup .NET 10.0.x]
    C --> D[dotnet restore]
    D --> E[SonarCloud begin scan]
    E --> F[dotnet build CrispyWaffle.sln]
    F --> G[dotnet test with coverage]
    G --> H{Coverage files generated}
    H -->|coverage.net10.0.opencover.xml| I[Report to SonarCloud]
    H -->|coverage.net10.0.opencover.xml| J[Report to Codecov]
    H -->|coverage.net10.0.opencover.xml| K[Report to Codacy]
    I & J & K --> L[SonarCloud end scan]
    L --> M[Collect binaries for TFMs: netstandard2.0 netstandard2.1 net8.0 net9.0 net10.0]
    M --> N[NuGet push PACKAGE_PROJECTS: Configuration ElasticSearch Elmah EventLog I18n.PtBr Log4Net RabbitMQ Redis Utils]
    N --> O[Tag release and create GitHub Release]

    subgraph notInSln [Not in solution or PACKAGE_PROJECTS]
        P[CrispyWaffle.BackgroundJobs TargetFramework: net10.0]
    end

    subgraph inSlnOnly [In solution, not in PACKAGE_PROJECTS]
        Q[CrispyWaffle.HttpClient TargetFramework: net10.0]
    end

    F -.->|built by sln| Q
    F -.->|NOT built| P
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASrc%2FCrispyWaffle.BackgroundJobs%2FCrispyWaffle.BackgroundJobs.csproj%3A3%0A**BackgroundJobs%20project%20not%20included%20in%20solution%20or%20CI**%0A%0A%60CrispyWaffle.BackgroundJobs%60%20is%20absent%20from%20%60CrispyWaffle.sln%60%20and%20from%20the%20%60PACKAGE_PROJECTS%60%20list%20in%20%60release.yml%60%2C%20so%20neither%20the%20build%20workflow%20%28%60dotnet%20build%20...%20CrispyWaffle.sln%60%29%20nor%20the%20release%20pipeline%20will%20compile%20or%20test%20this%20project.%20The%20%60TargetFramework%60%20change%20here%20from%20%60net8.0%60%20to%20%60net10.0%60%20is%20therefore%20never%20validated%20by%20CI.%20If%20this%20project%20is%20intended%20to%20become%20an%20active%20library%2C%20it%20should%20be%20added%20to%20the%20solution%3B%20if%20it%20is%20still%20experimental%2C%20the%20csproj%20change%20will%20remain%20unexercised%20and%20could%20silently%20drift%20out%20of%20sync%20with%20the%20rest%20of%20the%20build.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fbuild.yml%3A126%0A**Coverage%20path%20hardcodes%20TFM%20in%20multiple%20files**%0A%0AThe%20DeepSource%20coverage%20file%20path%20%28%60coverage.net10.0.cobertura.xml%60%29%20is%20hardcoded%20here%2C%20while%20equivalent%20hardcoded%20paths%20appear%20in%20%60release.yml%60%20for%20SonarCloud%2C%20Codecov%2C%20and%20Codacy.%20Every%20future%20TFM%20bump%20will%20require%20manually%20updating%20these%20four%20separate%20locations.%20Consider%20deriving%20the%20TFM%20from%20%60DotNetVersionTests%60%20via%20a%20workflow%20job%20output%20or%20a%20shared%20env%20variable%20to%20keep%20them%20in%20sync%20automatically.%0A%0A&repo=guibranco%2Fcrispywaffle&pr=971&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Src/CrispyWaffle.BackgroundJobs/CrispyWaffle.BackgroundJobs.csproj:3
**BackgroundJobs project not included in solution or CI**

`CrispyWaffle.BackgroundJobs` is absent from `CrispyWaffle.sln` and from the `PACKAGE_PROJECTS` list in `release.yml`, so neither the build workflow (`dotnet build ... CrispyWaffle.sln`) nor the release pipeline will compile or test this project. The `TargetFramework` change here from `net8.0` to `net10.0` is therefore never validated by CI. If this project is intended to become an active library, it should be added to the solution; if it is still experimental, the csproj change will remain unexercised and could silently drift out of sync with the rest of the build.

### Issue 2 of 2
.github/workflows/build.yml:126
**Coverage path hardcodes TFM in multiple files**

The DeepSource coverage file path (`coverage.net10.0.cobertura.xml`) is hardcoded here, while equivalent hardcoded paths appear in `release.yml` for SonarCloud, Codecov, and Codacy. Every future TFM bump will require manually updating these four separate locations. Consider deriving the TFM from `DotNetVersionTests` via a workflow job output or a shared env variable to keep them in sync automatically.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update to .NET 10 and adjust rela..."](https://github.com/guibranco/crispywaffle/commit/92d6a08b4e57b6b567ef7dd2050a43a31286b7e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47084230)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->