### PR TITLE
Add YAML serializer support +semver: minor

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
     <PackageVersion Include="System.Security.Permissions" Version="10.0.11" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.11" />
     <PackageVersion Include="System.Text.Json" Version="10.0.11" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Src/CrispyWaffle/CrispyWaffle.csproj
+++ b/Src/CrispyWaffle/CrispyWaffle.csproj
@@ -10,5 +10,6 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Security.Permissions" />
     <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 </Project>

--- a/Src/CrispyWaffle/Serialization/Adapters/IStringSerializerAdapter.cs
+++ b/Src/CrispyWaffle/Serialization/Adapters/IStringSerializerAdapter.cs
@@ -1,0 +1,17 @@
+namespace CrispyWaffle.Serialization.Adapters;
+
+/// <summary>
+/// Defines a serializer adapter that can serialize objects directly to strings.
+/// </summary>
+/// <seealso cref="ISerializerAdapter"/>
+public interface IStringSerializerAdapter : ISerializerAdapter
+{
+    /// <summary>
+    /// Serializes an object of type <typeparamref name="T"/> to its string representation.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to serialize.</typeparam>
+    /// <param name="deserialized">The object to serialize.</param>
+    /// <returns>The serialized string representation.</returns>
+    string SerializeToString<T>(T deserialized)
+        where T : class;
+}

--- a/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
+++ b/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
@@ -106,6 +106,7 @@ public sealed class YamlSerializerAdapter : BaseSerializerAdapter, IStringSerial
     private static IDeserializer CreateDeserializer() =>
         new DeserializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .WithDuplicateKeyChecking()
             .Build();
 
     /// <summary>

--- a/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
+++ b/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
@@ -95,9 +95,7 @@ public sealed class YamlSerializerAdapter : BaseSerializerAdapter, IStringSerial
     /// </summary>
     /// <returns>The configured YAML serializer.</returns>
     private static ISerializer CreateSerializer() =>
-        new SerializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
-            .Build();
+        new SerializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
 
     /// <summary>
     /// Creates the configured YAML deserializer.

--- a/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
+++ b/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using System.Text;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace CrispyWaffle.Serialization.Adapters;
+
+/// <summary>
+/// A YAML serializer adapter backed by YamlDotNet.
+/// </summary>
+/// <seealso cref="ISerializerAdapter" />
+public sealed class YamlSerializerAdapter : BaseSerializerAdapter
+{
+    /// <summary>
+    /// Deserialize a stream to a generic type.
+    /// </summary>
+    /// <typeparam name="T">Generic type parameter.</typeparam>
+    /// <param name="stream">The serialized object as stream.</param>
+    /// <param name="encoding">
+    /// (Optional) The encoding to read the stream. If null Encoding.UTF8 will be used.
+    /// </param>
+    /// <returns>A T.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="stream"/> is null.</exception>
+    public override T DeserializeFromStream<T>(Stream stream, Encoding encoding = null)
+        where T : class
+    {
+        if (stream == null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        using (
+            var reader = new StreamReader(
+                stream,
+                encoding ?? Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true,
+                bufferSize: 1024,
+                leaveOpen: true
+            )
+        )
+        {
+            return CreateDeserializer().Deserialize<T>(reader);
+        }
+    }
+
+    /// <summary>
+    /// Deserializes a YAML string to a generic type.
+    /// </summary>
+    /// <typeparam name="T">Generic type parameter.</typeparam>
+    /// <param name="serialized">The YAML serialized representation.</param>
+    /// <returns>A T.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="serialized"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="serialized"/> is not a string.</exception>
+    public override T Deserialize<T>(object serialized)
+        where T : class
+    {
+        if (serialized == null)
+        {
+            throw new ArgumentNullException(nameof(serialized));
+        }
+
+        if (serialized is not string yaml)
+        {
+            throw new ArgumentException("Serialized YAML must be a string.", nameof(serialized));
+        }
+
+        return CreateDeserializer().Deserialize<T>(yaml);
+    }
+
+    /// <summary>
+    /// Serializes an object of type <typeparamref name="T"/> into YAML and outputs it to a stream.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to be serialized.</typeparam>
+    /// <param name="deserialized">The object to serialize.</param>
+    /// <param name="stream">An output stream containing the serialized YAML.</param>
+    public override void Serialize<T>(T deserialized, out Stream stream)
+        where T : class
+    {
+        stream = new MemoryStream();
+        if (deserialized == null)
+        {
+            return;
+        }
+
+        var yaml = CreateSerializer().Serialize(deserialized);
+        var bytes = Encoding.UTF8.GetBytes(yaml);
+        stream.Write(bytes, 0, bytes.Length);
+        stream.Seek(0, SeekOrigin.Begin);
+    }
+
+    /// <summary>
+    /// Creates the configured YAML serializer.
+    /// </summary>
+    /// <returns>The configured YAML serializer.</returns>
+    private static ISerializer CreateSerializer() =>
+        new SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build();
+
+    /// <summary>
+    /// Creates the configured YAML deserializer.
+    /// </summary>
+    /// <returns>The configured YAML deserializer.</returns>
+    private static IDeserializer CreateDeserializer() =>
+        new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build();
+}

--- a/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
+++ b/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
@@ -10,8 +10,23 @@ namespace CrispyWaffle.Serialization.Adapters;
 /// A YAML serializer adapter backed by YamlDotNet.
 /// </summary>
 /// <seealso cref="ISerializerAdapter" />
-public sealed class YamlSerializerAdapter : BaseSerializerAdapter
+/// <seealso cref="IStringSerializerAdapter" />
+public sealed class YamlSerializerAdapter : BaseSerializerAdapter, IStringSerializerAdapter
 {
+    /// <summary>
+    /// The configured YAML serializer.
+    /// </summary>
+    private static readonly ISerializer _serializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    /// <summary>
+    /// The configured YAML deserializer.
+    /// </summary>
+    private static readonly IDeserializer _deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
     /// <summary>
     /// Deserialize a stream to a generic type.
     /// </summary>
@@ -40,7 +55,7 @@ public sealed class YamlSerializerAdapter : BaseSerializerAdapter
             )
         )
         {
-            return CreateDeserializer().Deserialize<T>(reader);
+            return _deserializer.Deserialize<T>(reader);
         }
     }
 
@@ -65,7 +80,7 @@ public sealed class YamlSerializerAdapter : BaseSerializerAdapter
             throw new ArgumentException("Serialized YAML must be a string.", nameof(serialized));
         }
 
-        return CreateDeserializer().Deserialize<T>(yaml);
+        return _deserializer.Deserialize<T>(yaml);
     }
 
     /// <summary>
@@ -78,32 +93,23 @@ public sealed class YamlSerializerAdapter : BaseSerializerAdapter
         where T : class
     {
         stream = new MemoryStream();
-        if (deserialized == null)
+        var yaml = SerializeToString(deserialized);
+        if (yaml.Length == 0)
         {
             return;
         }
 
-        var yaml = CreateSerializer().Serialize(deserialized);
         var bytes = Encoding.UTF8.GetBytes(yaml);
         stream.Write(bytes, 0, bytes.Length);
         stream.Seek(0, SeekOrigin.Begin);
     }
 
     /// <summary>
-    /// Creates the configured YAML serializer.
+    /// Serializes an object of type <typeparamref name="T"/> into a YAML string.
     /// </summary>
-    /// <returns>The configured YAML serializer.</returns>
-    private static ISerializer CreateSerializer() =>
-        new SerializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
-            .Build();
-
-    /// <summary>
-    /// Creates the configured YAML deserializer.
-    /// </summary>
-    /// <returns>The configured YAML deserializer.</returns>
-    private static IDeserializer CreateDeserializer() =>
-        new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
-            .Build();
+    /// <typeparam name="T">The type of the object to be serialized.</typeparam>
+    /// <param name="deserialized">The object to serialize.</param>
+    /// <returns>The YAML string representation, or an empty string when the object is null.</returns>
+    public string SerializeToString<T>(T deserialized)
+        where T : class => deserialized == null ? string.Empty : _serializer.Serialize(deserialized);
 }

--- a/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
+++ b/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
@@ -31,18 +31,15 @@ public sealed class YamlSerializerAdapter : BaseSerializerAdapter, IStringSerial
             throw new ArgumentNullException(nameof(stream));
         }
 
-        using (
-            var reader = new StreamReader(
-                stream,
-                encoding ?? Encoding.UTF8,
-                detectEncodingFromByteOrderMarks: true,
-                bufferSize: 1024,
-                leaveOpen: true
-            )
-        )
-        {
-            return CreateDeserializer().Deserialize<T>(reader);
-        }
+        using var reader = new StreamReader(
+            stream,
+            encoding ?? Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true,
+            bufferSize: 1024,
+            leaveOpen: true
+        );
+
+        return CreateDeserializer().Deserialize<T>(reader);
     }
 
     /// <summary>

--- a/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
+++ b/Src/CrispyWaffle/Serialization/Adapters/YamlSerializerAdapter.cs
@@ -14,20 +14,6 @@ namespace CrispyWaffle.Serialization.Adapters;
 public sealed class YamlSerializerAdapter : BaseSerializerAdapter, IStringSerializerAdapter
 {
     /// <summary>
-    /// The configured YAML serializer.
-    /// </summary>
-    private static readonly ISerializer _serializer = new SerializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .Build();
-
-    /// <summary>
-    /// The configured YAML deserializer.
-    /// </summary>
-    private static readonly IDeserializer _deserializer = new DeserializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .Build();
-
-    /// <summary>
     /// Deserialize a stream to a generic type.
     /// </summary>
     /// <typeparam name="T">Generic type parameter.</typeparam>
@@ -55,7 +41,7 @@ public sealed class YamlSerializerAdapter : BaseSerializerAdapter, IStringSerial
             )
         )
         {
-            return _deserializer.Deserialize<T>(reader);
+            return CreateDeserializer().Deserialize<T>(reader);
         }
     }
 
@@ -80,7 +66,7 @@ public sealed class YamlSerializerAdapter : BaseSerializerAdapter, IStringSerial
             throw new ArgumentException("Serialized YAML must be a string.", nameof(serialized));
         }
 
-        return _deserializer.Deserialize<T>(yaml);
+        return CreateDeserializer().Deserialize<T>(yaml);
     }
 
     /// <summary>
@@ -105,11 +91,29 @@ public sealed class YamlSerializerAdapter : BaseSerializerAdapter, IStringSerial
     }
 
     /// <summary>
+    /// Creates the configured YAML serializer.
+    /// </summary>
+    /// <returns>The configured YAML serializer.</returns>
+    private static ISerializer CreateSerializer() =>
+        new SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build();
+
+    /// <summary>
+    /// Creates the configured YAML deserializer.
+    /// </summary>
+    /// <returns>The configured YAML deserializer.</returns>
+    private static IDeserializer CreateDeserializer() =>
+        new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build();
+
+    /// <summary>
     /// Serializes an object of type <typeparamref name="T"/> into a YAML string.
     /// </summary>
     /// <typeparam name="T">The type of the object to be serialized.</typeparam>
     /// <param name="deserialized">The object to serialize.</param>
     /// <returns>The YAML string representation, or an empty string when the object is null.</returns>
     public string SerializeToString<T>(T deserialized)
-        where T : class => deserialized == null ? string.Empty : _serializer.Serialize(deserialized);
+        where T : class => deserialized == null ? string.Empty : CreateSerializer().Serialize(deserialized);
 }

--- a/Src/CrispyWaffle/Serialization/SerializerConverter.cs
+++ b/Src/CrispyWaffle/Serialization/SerializerConverter.cs
@@ -152,14 +152,9 @@ public sealed class SerializerConverter<T>(T obj, ISerializerAdapter formatter)
             return json.ToString();
         }
 
-        if (instance._formatter is YamlSerializerAdapter)
+        if (instance._formatter is IStringSerializerAdapter stringSerializer)
         {
-            instance._formatter.Serialize(instance._obj, out var stream);
-            using (stream)
-            using (var reader = new StreamReader(stream, Encoding.UTF8))
-            {
-                return reader.ReadToEnd();
-            }
+            return stringSerializer.SerializeToString(instance._obj);
         }
 
         throw new InvalidOperationException(

--- a/Src/CrispyWaffle/Serialization/SerializerConverter.cs
+++ b/Src/CrispyWaffle/Serialization/SerializerConverter.cs
@@ -152,6 +152,16 @@ public sealed class SerializerConverter<T>(T obj, ISerializerAdapter formatter)
             return json.ToString();
         }
 
+        if (instance._formatter is YamlSerializerAdapter)
+        {
+            instance._formatter.Serialize(instance._obj, out var stream);
+            using (stream)
+            using (var reader = new StreamReader(stream, Encoding.UTF8))
+            {
+                return reader.ReadToEnd();
+            }
+        }
+
         throw new InvalidOperationException(
             $"The type {typeof(T).FullName} doesn't allow string explicit conversion"
         );

--- a/Src/CrispyWaffle/Serialization/SerializerFactory.cs
+++ b/Src/CrispyWaffle/Serialization/SerializerFactory.cs
@@ -203,6 +203,12 @@ public static class SerializerFactory
                     ServiceLocator.Resolve<XmlSerializerAdapter>()
                 );
 
+            case SerializerFormat.Yaml:
+                return new SerializerConverter<T>(
+                    obj,
+                    ServiceLocator.Resolve<YamlSerializerAdapter>()
+                );
+
             default:
                 throw new InvalidOperationException(nameof(attribute.Format));
         }

--- a/Src/CrispyWaffle/Serialization/SerializerFormat.cs
+++ b/Src/CrispyWaffle/Serialization/SerializerFormat.cs
@@ -24,4 +24,10 @@ public enum SerializerFormat
     /// </summary>
     [HumanReadable("XML")]
     Xml,
+
+    /// <summary>
+    ///     An enum constant representing the YAML option.
+    /// </summary>
+    [HumanReadable("YAML")]
+    Yaml,
 }

--- a/Tests/CrispyWaffle.Tests/Serialization/SerializerFactoryTests.cs
+++ b/Tests/CrispyWaffle.Tests/Serialization/SerializerFactoryTests.cs
@@ -36,6 +36,24 @@ public class SerializerFactoryTests
     }
 
     [Fact]
+    public void ValidateSerializerYaml()
+    {
+        var deserialized = new SampleYamlClass { Name = "Jane Doe", Age = 25 };
+
+        var serializedResult = (string)deserialized.GetSerializer();
+
+        Assert.Contains("name: Jane Doe", serializedResult);
+        Assert.Contains("age: 25", serializedResult);
+
+        var deserializedResult = SerializerFactory
+            .GetSerializer<SampleYamlClass>()
+            .Deserialize(serializedResult);
+
+        Assert.Equal(deserialized.Name, deserializedResult.Name);
+        Assert.Equal(deserialized.Age, deserializedResult.Age);
+    }
+
+    [Fact]
     public void ValidateGetSerializerJsonNotStrict()
     {
         var deserialized = TestObjects.GetSampleJsonNotStrict();

--- a/Tests/CrispyWaffle.Tests/Serialization/TestObjects_/SampleYamlClass.cs
+++ b/Tests/CrispyWaffle.Tests/Serialization/TestObjects_/SampleYamlClass.cs
@@ -1,0 +1,13 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using CrispyWaffle.Serialization;
+
+namespace CrispyWaffle.Tests.Serialization;
+
+[Serializer(SerializerFormat.Yaml)]
+[ExcludeFromCodeCoverage]
+public class SampleYamlClass
+{
+    public string Name { get; set; }
+
+    public int Age { get; set; }
+}

--- a/Tests/CrispyWaffle.Tests/Serialization/YamlSerializerAdapterTests.cs
+++ b/Tests/CrispyWaffle.Tests/Serialization/YamlSerializerAdapterTests.cs
@@ -28,6 +28,22 @@ public class YamlSerializerAdapterTests
     }
 
     [Fact]
+    public void SerializeWithNullObjectProducesEmptyStream()
+    {
+        // Act
+        _serializer.Serialize<SampleYamlClass>(null, out var stream);
+
+        using (stream)
+        {
+            // Assert
+            stream.Should().NotBeNull();
+            stream.CanRead.Should().BeTrue();
+            stream.Length.Should().Be(0);
+            stream.Position.Should().Be(0);
+        }
+    }
+
+    [Fact]
     public void DeserializeWithValidYamlReturnsObject()
     {
         // Arrange

--- a/Tests/CrispyWaffle.Tests/Serialization/YamlSerializerAdapterTests.cs
+++ b/Tests/CrispyWaffle.Tests/Serialization/YamlSerializerAdapterTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using CrispyWaffle.Serialization.Adapters;
 using FluentAssertions;
+using YamlDotNet.Core;
 using Xunit;
 
 namespace CrispyWaffle.Tests.Serialization;
@@ -54,6 +55,19 @@ public class YamlSerializerAdapterTests
 
         // Assert
         result.Should().BeEquivalentTo(GenerateSampleData());
+    }
+
+    [Fact]
+    public void DeserializeWithDuplicateKeysThrowsYamlException()
+    {
+        // Arrange
+        const string yaml = "name: Jane Doe\nname: John Doe\nage: 25\n";
+
+        // Act
+        Action act = () => _serializer.Deserialize<SampleYamlClass>(yaml);
+
+        // Assert
+        act.Should().Throw<YamlException>();
     }
 
     [Fact]

--- a/Tests/CrispyWaffle.Tests/Serialization/YamlSerializerAdapterTests.cs
+++ b/Tests/CrispyWaffle.Tests/Serialization/YamlSerializerAdapterTests.cs
@@ -3,8 +3,8 @@ using System.IO;
 using System.Text;
 using CrispyWaffle.Serialization.Adapters;
 using FluentAssertions;
-using YamlDotNet.Core;
 using Xunit;
+using YamlDotNet.Core;
 
 namespace CrispyWaffle.Tests.Serialization;
 

--- a/Tests/CrispyWaffle.Tests/Serialization/YamlSerializerAdapterTests.cs
+++ b/Tests/CrispyWaffle.Tests/Serialization/YamlSerializerAdapterTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using CrispyWaffle.Serialization.Adapters;
+using FluentAssertions;
+using Xunit;
+
+namespace CrispyWaffle.Tests.Serialization;
+
+public class YamlSerializerAdapterTests
+{
+    private readonly YamlSerializerAdapter _serializer = new();
+
+    [Fact]
+    public void SerializeWithValidObjectReturnsYaml()
+    {
+        // Arrange
+        var instance = GenerateSampleData();
+
+        // Act
+        _serializer.Serialize(instance, out var stream);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var yaml = reader.ReadToEnd();
+
+        // Assert
+        yaml.Should().Contain("name: Jane Doe");
+        yaml.Should().Contain("age: 25");
+    }
+
+    [Fact]
+    public void DeserializeWithValidYamlReturnsObject()
+    {
+        // Arrange
+        const string yaml = "name: Jane Doe\nage: 25\n";
+
+        // Act
+        var result = _serializer.Deserialize<SampleYamlClass>(yaml);
+
+        // Assert
+        result.Should().BeEquivalentTo(GenerateSampleData());
+    }
+
+    [Fact]
+    public void DeserializeFromStreamWithValidYamlReturnsObjectAndKeepsStreamOpen()
+    {
+        // Arrange
+        const string yaml = "name: Jane Doe\nage: 25\n";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(yaml));
+
+        // Act
+        var result = _serializer.DeserializeFromStream<SampleYamlClass>(stream);
+
+        // Assert
+        result.Should().BeEquivalentTo(GenerateSampleData());
+        stream.CanRead.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SaveAndLoadRoundTripReturnsEquivalentObject()
+    {
+        // Arrange
+        var fileName = Path.GetTempFileName();
+        var instance = GenerateSampleData();
+
+        try
+        {
+            // Act
+            _serializer.Save(fileName, instance);
+            var result = _serializer.Load<SampleYamlClass>(fileName);
+
+            // Assert
+            result.Should().BeEquivalentTo(instance);
+        }
+        finally
+        {
+            if (File.Exists(fileName))
+            {
+                File.Delete(fileName);
+            }
+        }
+    }
+
+    [Fact]
+    public void DeserializeFromNullStreamThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _serializer.DeserializeFromStream<SampleYamlClass>(null)
+        );
+    }
+
+    private static SampleYamlClass GenerateSampleData() => new() { Name = "Jane Doe", Age = 25 };
+}

--- a/Tests/CrispyWaffle.Tests/Serialization/YamlSerializerAdapterTests.cs
+++ b/Tests/CrispyWaffle.Tests/Serialization/YamlSerializerAdapterTests.cs
@@ -45,6 +45,16 @@ public class YamlSerializerAdapterTests
     }
 
     [Fact]
+    public void SerializeToStringWithNullReturnsEmptyString()
+    {
+        // Act
+        var result = _serializer.SerializeToString<SampleYamlClass>(null);
+
+        // Assert
+        result.Should().Be(string.Empty);
+    }
+
+    [Fact]
     public void DeserializeWithValidYamlReturnsObject()
     {
         // Arrange
@@ -68,6 +78,31 @@ public class YamlSerializerAdapterTests
 
         // Assert
         act.Should().Throw<YamlException>();
+    }
+
+    [Fact]
+    public void DeserializeWithNullSerializedThrowsArgumentNullException()
+    {
+        // Act
+        Action act = () => _serializer.Deserialize<SampleYamlClass>(null);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("serialized");
+    }
+
+    [Fact]
+    public void DeserializeWithNonStringSerializedThrowsArgumentException()
+    {
+        // Arrange
+        var invalidInput = new StringBuilder("not a string");
+
+        // Act
+        Action act = () => _serializer.Deserialize<SampleYamlClass>(invalidInput);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .And.ParamName.Should().Be("serialized");
     }
 
     [Fact]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-- Add YAML serializer support using YamlDotNet - [issue #432](https://github.com/guibranco/CrispyWaffle/issues/432) by [@rodri-oliveira-dev](https://github.com/rodri-oliveira-dev)
+- Add YAML serializer support using YamlDotNet -
+  [issue #432][issue-432] by [@rodri-oliveira-dev][rodri]
+
+[issue-432]: https://github.com/guibranco/CrispyWaffle/issues/432
+[rodri]: https://github.com/rodri-oliveira-dev
 
 ## Version 10.0 [2025-02-22]
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add YAML serializer support using YamlDotNet - [issue #432](https://github.com/guibranco/CrispyWaffle/issues/432) by [@rodri-oliveira-dev](https://github.com/rodri-oliveira-dev)
+
 ## Version 10.0 [2025-02-22]
 
 - Drop support to .NET 6 - [pull request #667](https://github.com/guibranco/CrispyWaffle/pull/667)

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -20,7 +20,7 @@ Crispy Waffle is a versatile toolkit for .NET projects, offering a wide range of
 
 - **Scheduled Task Execution**: Automate the execution of tasks at defined intervals. [Learn More](scheduled-jobs.md)
 
-- **Serialization Helpers**: Easily serialize and deserialize data in JSON and XML formats.
+- **Serialization Helpers**: Easily serialize and deserialize data in JSON, XML, and YAML formats. [Learn More](serialization.md)
 
 - **Service Locator**: Acts as a Dependency Injection and Inversion of Control (IoC) container. [Learn More](service-locator.md)
 

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -20,7 +20,8 @@ Crispy Waffle is a versatile toolkit for .NET projects, offering a wide range of
 
 - **Scheduled Task Execution**: Automate the execution of tasks at defined intervals. [Learn More](scheduled-jobs.md)
 
-- **Serialization Helpers**: Easily serialize and deserialize data in JSON, XML, and YAML formats. [Learn More](serialization.md)
+- **Serialization Helpers**: Easily serialize and deserialize data in JSON, XML,
+  and YAML formats. [Learn More](serialization.md)
 
 - **Service Locator**: Acts as a Dependency Injection and Inversion of Control (IoC) container. [Learn More](service-locator.md)
 

--- a/docs/user-guide/serialization.md
+++ b/docs/user-guide/serialization.md
@@ -1,6 +1,9 @@
 # Serialization
 
-Crispy Waffle provides serializer adapters for JSON, XML, and YAML. YAML support is implemented with [YamlDotNet](https://github.com/aaubry/YamlDotNet) and uses camel-case property names by default.
+Crispy Waffle provides serializer adapters for JSON, XML, and YAML. YAML
+support is implemented with
+[YamlDotNet](https://github.com/aaubry/YamlDotNet) and uses camel-case property
+names by default.
 
 ## YAML with `SerializerAttribute`
 
@@ -60,11 +63,13 @@ var loaded = SerializerFactory
 
 ## Selecting YAML explicitly
 
-When a type should not use YAML as its default serializer, request it explicitly with `GetCustomSerializer`:
+When a type should not use YAML as its default serializer, request it
+explicitly with `GetCustomSerializer`:
 
 ```csharp
 var yamlSerializer = settings.GetCustomSerializer(SerializerFormat.Yaml);
 var yaml = (string)yamlSerializer;
 ```
 
-This keeps YAML consistent with the existing serializer abstraction instead of requiring direct YamlDotNet usage in application code.
+This keeps YAML consistent with the existing serializer abstraction instead
+of requiring direct YamlDotNet usage in application code.

--- a/docs/user-guide/serialization.md
+++ b/docs/user-guide/serialization.md
@@ -1,0 +1,70 @@
+# Serialization
+
+Crispy Waffle provides serializer adapters for JSON, XML, and YAML. YAML support is implemented with [YamlDotNet](https://github.com/aaubry/YamlDotNet) and uses camel-case property names by default.
+
+## YAML with `SerializerAttribute`
+
+Annotate a class with `SerializerFormat.Yaml` to make YAML its default serializer:
+
+```csharp
+using CrispyWaffle.Serialization;
+
+[Serializer(SerializerFormat.Yaml)]
+public class AppSettings
+{
+    public string ApplicationName { get; set; }
+
+    public int RetryCount { get; set; }
+}
+```
+
+Serialize an instance to a YAML string:
+
+```csharp
+var settings = new AppSettings
+{
+    ApplicationName = "Crispy Waffle",
+    RetryCount = 3,
+};
+
+var yaml = (string)settings.GetSerializer();
+```
+
+The generated YAML uses camel-case property names:
+
+```yaml
+applicationName: Crispy Waffle
+retryCount: 3
+```
+
+Deserialize the YAML back to the annotated type:
+
+```csharp
+var settings = SerializerFactory
+    .GetSerializer<AppSettings>()
+    .Deserialize(yaml);
+```
+
+## Saving and loading YAML files
+
+The YAML adapter supports the same file APIs exposed by the other serializer adapters:
+
+```csharp
+var serializer = settings.GetSerializer();
+serializer.Save("settings.yaml");
+
+var loaded = SerializerFactory
+    .GetSerializer<AppSettings>()
+    .Load("settings.yaml");
+```
+
+## Selecting YAML explicitly
+
+When a type should not use YAML as its default serializer, request it explicitly with `GetCustomSerializer`:
+
+```csharp
+var yamlSerializer = settings.GetCustomSerializer(SerializerFormat.Yaml);
+var yaml = (string)yamlSerializer;
+```
+
+This keeps YAML consistent with the existing serializer abstraction instead of requiring direct YamlDotNet usage in application code.

--- a/docs/user-guide/serialization.md
+++ b/docs/user-guide/serialization.md
@@ -7,7 +7,8 @@ names by default.
 
 ## YAML with `SerializerAttribute`
 
-Annotate a class with `SerializerFormat.Yaml` to make YAML its default serializer:
+Annotate a class with `SerializerFormat.Yaml` to make YAML its default
+serializer:
 
 ```csharp
 using CrispyWaffle.Serialization;
@@ -50,7 +51,8 @@ var settings = SerializerFactory
 
 ## Saving and loading YAML files
 
-The YAML adapter supports the same file APIs exposed by the other serializer adapters:
+The YAML adapter supports the same file APIs exposed by the other serializer
+adapters:
 
 ```csharp
 var serializer = settings.GetSerializer();


### PR DESCRIPTION
## Summary

Adds YAML serialization support using YamlDotNet, as discussed in #432.

## Changes

- Add `SerializerFormat.Yaml`
- Add `YamlSerializerAdapter` backed by YamlDotNet
- Integrate YAML with `SerializerFactory`
- Add YAML-to-string conversion in `SerializerConverter`
- Support stream, file, and string serialization/deserialization
- Add unit tests for the YAML adapter and factory integration
- Add user guide documentation and changelog entry
- Use `+semver: minor` as required by the issue

## Implementation details

- Uses YamlDotNet 18.1.0
- Uses `CamelCaseNamingConvention.Instance`, following the repository PoC
- Keeps caller-owned streams open during deserialization
- Preserves existing `SerializerFormat` enum values by appending `Yaml`
- Documents the new adapter and methods using .NET XML documentation comments

## Validation

- Restore passed
- Release build passed
- YAML/serialization tests passed
- Full CrispyWaffle test suite passed

Closes #432

## Summary by Sourcery

Add YAML serialization support to the serialization framework.

New Features:
- Add YAML serialization and deserialization through a YamlDotNet-backed adapter, including string, stream, and file workflows.
- Expose YAML selection through the serializer format and factory APIs.

Enhancements:
- Allow serializer conversion to produce strings through string-capable adapters.
- Preserve caller-owned streams during YAML deserialization and reject duplicate YAML keys.

Build:
- Add the YamlDotNet package dependency.

Documentation:
- Document YAML serialization usage and add it to the user guide and changelog.

Tests:
- Add coverage for YAML adapter behavior, validation, round trips, and factory integration.

Chores:
- Introduce a shared string serializer adapter contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added YAML serialization and deserialization support.
  - Supports string, stream, and file-based YAML workflows.
  - YAML output uses camel-case naming and detects duplicate keys.
  - Added YAML as a selectable serialization format.

- **Documentation**
  - Added YAML usage guidance and examples.
  - Updated supported format documentation.

- **Tests**
  - Added coverage for YAML conversion, round trips, stream handling, duplicate keys, null values, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->